### PR TITLE
添加 HTTP 基本认证

### DIFF
--- a/app/src/main/java/moe/shizuku/fcmformojo/FFMApplication.java
+++ b/app/src/main/java/moe/shizuku/fcmformojo/FFMApplication.java
@@ -6,10 +6,12 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.os.Handler;
 
+import moe.shizuku.fcmformojo.interceptor.HttpBasicAuthorizationInterceptor;
 import moe.shizuku.fcmformojo.notification.NotificationBuilder;
 import moe.shizuku.fcmformojo.utils.UsageStatsUtils;
 import moe.shizuku.privileged.api.PrivilegedManager;
 import moe.shizuku.support.utils.Settings;
+import okhttp3.OkHttpClient;
 import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
 
@@ -44,9 +46,14 @@ public class FFMApplication extends Application {
 
         mNotificationBuilder = new NotificationBuilder(this);
 
+        OkHttpClient mOkHttpClient = new OkHttpClient.Builder()
+                .addInterceptor(new HttpBasicAuthorizationInterceptor())
+                .build();
+
         mRetrofit = new Retrofit.Builder()
                 .baseUrl(FFMSettings.getBaseUrl())
                 .addConverterFactory(GsonConverterFactory.create())
+                .client(mOkHttpClient)
                 .build();
 
         try {

--- a/app/src/main/java/moe/shizuku/fcmformojo/FFMSettings.java
+++ b/app/src/main/java/moe/shizuku/fcmformojo/FFMSettings.java
@@ -12,6 +12,8 @@ import moe.shizuku.support.utils.Settings;
 public class FFMSettings {
 
     public static final String BASE_URL = "server_url";
+    public static final String SERVER_HTTP_USERNAME = "server_http_username";
+    public static final String SERVER_HTTP_PASSWORD = "server_http_password";
     public static final String QQ_PACKAGE = "qq_package";
     public static final String NOTIFICATION_NAME = "notification_app_name";
     public static final String GET_FOREGROUND = "get_foreground";

--- a/app/src/main/java/moe/shizuku/fcmformojo/interceptor/HttpBasicAuthorizationInterceptor.java
+++ b/app/src/main/java/moe/shizuku/fcmformojo/interceptor/HttpBasicAuthorizationInterceptor.java
@@ -1,0 +1,34 @@
+package moe.shizuku.fcmformojo.interceptor;
+
+import android.util.Base64;
+
+import java.io.IOException;
+
+import moe.shizuku.fcmformojo.FFMSettings;
+import moe.shizuku.support.utils.Settings;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+/**
+ * OkHttp Interceptor for adding http basic authorization header
+ * @author Haruue Icymoon haruue@caoyue.com.cn
+ */
+
+public class HttpBasicAuthorizationInterceptor implements Interceptor {
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        Request request = chain.request();
+        String username = Settings.getString(FFMSettings.SERVER_HTTP_USERNAME, null);
+        String password = Settings.getString(FFMSettings.SERVER_HTTP_PASSWORD, null);
+        if (username != null && username.length() > 0
+                || password != null && password.length() > 0) {
+            String authorization = "Basic " + Base64.encodeToString((username + ':' + password).getBytes(), Base64.NO_WRAP);
+            request = request.newBuilder()
+                    .addHeader("Authorization", authorization)
+                    .build();
+        }
+        return chain.proceed(request);
+    }
+}

--- a/app/src/main/java/moe/shizuku/fcmformojo/preference/HttpUriPreference.java
+++ b/app/src/main/java/moe/shizuku/fcmformojo/preference/HttpUriPreference.java
@@ -1,0 +1,191 @@
+package moe.shizuku.fcmformojo.preference;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
+import android.support.v4.content.res.TypedArrayUtils;
+import android.text.TextUtils;
+import android.util.AttributeSet;
+
+import moe.shizuku.fcmformojo.R;
+import moe.shizuku.support.preference.DialogPreference;
+import moe.shizuku.support.preference.PreferenceDialogFragment;
+import moe.shizuku.support.utils.Settings;
+
+/**
+ * Preference to set http uri, http username and http password
+ * @author Haruue Icymoon haruue@caoyue.com.cn
+ */
+
+@SuppressWarnings({"RestrictedApi", "WeakerAccess", "unused"})
+public class HttpUriPreference extends DialogPreference {
+
+    private String uri;
+    private String username;
+    private String password;
+
+    private String mSummary;
+    private String mSummaryWhenAuthorizationSet;
+    private String keyUsername;
+    private String keyPassword;
+
+    private OnPreferenceChangeListener onUsernameChangeListener;
+    private OnPreferenceChangeListener onPasswordChangeListener;
+
+    public HttpUriPreference(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+        TypedArray a;
+
+        a = context.obtainStyledAttributes(attrs, R.styleable.HttpUriPreference);
+        mSummaryWhenAuthorizationSet = a.getString(R.styleable.HttpUriPreference_summary_when_authorization_set);
+        keyUsername = a.getString(R.styleable.HttpUriPreference_key_http_username);
+        keyPassword = a.getString(R.styleable.HttpUriPreference_key_http_password);
+        a.recycle();
+
+        a = context.obtainStyledAttributes(attrs,
+                R.styleable.Preference, defStyleAttr, defStyleRes);
+        mSummary = TypedArrayUtils.getString(a, R.styleable.Preference_summary,
+                R.styleable.Preference_android_summary);
+        a.recycle();
+
+        setDialogLayoutResource(R.layout.dialog_http_uri_preference);
+
+    }
+
+    public HttpUriPreference(Context context, AttributeSet attrs, int defStyleAttr) {
+        this(context, attrs, defStyleAttr, 0);
+    }
+
+    public HttpUriPreference(Context context, AttributeSet attrs) {
+        this(context, attrs, R.attr.dialogPreferenceStyle);
+    }
+
+    public HttpUriPreference(Context context) {
+        this(context, null);
+    }
+
+    @NonNull
+    @Override
+    protected DialogFragment onCreateDialogFragment(String key) {
+        final HttpUriPreferenceDialogFragment fragment = new HttpUriPreferenceDialogFragment();
+        final Bundle b  = new Bundle(1);
+        b.putString(PreferenceDialogFragment.ARG_KEY, key);
+        b.putString(HttpUriPreferenceDialogFragment.ARG_KEY_USERNAME, keyUsername);
+        b.putString(HttpUriPreferenceDialogFragment.ARG_KEY_PASSWORD, keyPassword);
+        fragment.setArguments(b);
+        return fragment;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public void setUri(String uri) {
+        final boolean wasBlocking = shouldDisableDependents();
+        final boolean changed = !TextUtils.equals(this.uri, uri);
+        this.uri = uri;
+
+        if (changed) {
+            persistString(uri);
+            notifyChanged();
+        }
+
+        final boolean isBlocking = shouldDisableDependents();
+        if (isBlocking != wasBlocking) {
+            notifyDependencyChange(isBlocking);
+        }
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        final boolean changed = !TextUtils.equals(this.username, username);
+        this.username = username;
+
+        if (changed) {
+            setString(keyUsername, username);
+            notifyChanged();
+        }
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        final boolean changed = !TextUtils.equals(this.password, password);
+        this.password = password;
+
+        if (changed) {
+            setString(keyPassword, password);
+            notifyChanged();
+        }
+    }
+
+    private void setString(String key, String value) {
+        Settings.putString(key, value);
+    }
+
+    public void setOnUsernameChangeListener(OnPreferenceChangeListener onUsernameChangeListener) {
+        this.onUsernameChangeListener = onUsernameChangeListener;
+    }
+
+    public void setOnPasswordChangeListener(OnPreferenceChangeListener onPasswordChangeListener) {
+        this.onPasswordChangeListener = onPasswordChangeListener;
+    }
+
+    public boolean callOnUsernameChangeListener(Object newValue) {
+        return onUsernameChangeListener == null || onUsernameChangeListener.onPreferenceChange(this, newValue);
+    }
+
+    public boolean callOnPasswordChangeListener(Object newValue) {
+        return onPasswordChangeListener == null || onPasswordChangeListener.onPreferenceChange(this, newValue);
+    }
+
+    @Override
+    protected Object onGetDefaultValue(TypedArray a, int index) {
+        return a.getString(index);
+    }
+
+    @Override
+    protected void onSetInitialValue(boolean restorePersistedValue, Object defaultValue) {
+        setUri(restorePersistedValue ? getPersistedString(uri) : (String) defaultValue);
+        setUsername(Settings.getString(keyUsername, null));
+        setPassword(Settings.getString(keyPassword, null));
+    }
+
+
+    @Override
+    public CharSequence getSummary() {
+        final CharSequence uri = getUri();
+        final CharSequence username = getUsername();
+        if (mSummary == null) {
+            return super.getSummary();
+        } else {
+            if (uri != null) {
+                if (username != null && username.length() != 0) {
+                    return String.format(mSummaryWhenAuthorizationSet, uri);
+                } else {
+                    return String.format(mSummary, uri);
+                }
+            } else {
+                return "";
+            }
+        }
+    }
+
+
+    @Override
+    public void setSummary(CharSequence summary) {
+        super.setSummary(summary);
+        if (summary == null && mSummary != null) {
+            mSummary = null;
+        } else if (summary != null && !summary.equals(mSummary)) {
+            mSummary = summary.toString();
+        }
+    }
+}

--- a/app/src/main/java/moe/shizuku/fcmformojo/preference/HttpUriPreferenceDialogFragment.java
+++ b/app/src/main/java/moe/shizuku/fcmformojo/preference/HttpUriPreferenceDialogFragment.java
@@ -1,0 +1,89 @@
+package moe.shizuku.fcmformojo.preference;
+
+import android.content.Context;
+import android.view.View;
+import android.view.inputmethod.InputMethodManager;
+import android.widget.CheckBox;
+import android.widget.CompoundButton;
+import android.widget.EditText;
+import android.widget.LinearLayout;
+
+import moe.shizuku.fcmformojo.R;
+import moe.shizuku.support.preference.PreferenceDialogFragment;
+
+/**
+ * DialogFragment for {@link HttpUriPreference}
+ * @author Haruue Icymoon haruue@caoyue.com.cn
+ */
+
+public class HttpUriPreferenceDialogFragment extends PreferenceDialogFragment {
+
+    public static final String ARG_KEY_USERNAME = "key_username";
+    public static final String ARG_KEY_PASSWORD = "key_password";
+
+    private CheckBox advancedOptionsCheckBox;
+    private LinearLayout advancedOptionsContainer;
+
+    private EditText uriEditText;
+    private EditText usernameEditText;
+    private EditText passwordEditText;
+
+    @Override
+    protected void onBindDialogView(View view) {
+        super.onBindDialogView(view);
+        // bind view
+        advancedOptionsCheckBox = (CheckBox) view.findViewById(R.id.cb_advanced_options);
+        advancedOptionsContainer = (LinearLayout) view.findViewById(R.id.ll_advanced_options_container);
+        uriEditText = (EditText) view.findViewById(R.id.et_uri);
+        usernameEditText = (EditText) view.findViewById(R.id.et_http_username);
+        passwordEditText = (EditText) view.findViewById(R.id.et_http_password);
+        // default value
+        uriEditText.setText(getHttpUriPreference().getUri());
+        usernameEditText.setText(getHttpUriPreference().getUsername());
+        passwordEditText.setText(getHttpUriPreference().getPassword());
+        // advanced options expand
+        advancedOptionsCheckBox.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                if (isChecked) {
+                    advancedOptionsCheckBox.setVisibility(View.GONE);
+                    advancedOptionsContainer.setVisibility(View.VISIBLE);
+                }
+            }
+        });
+        if (usernameEditText.length() != 0) {
+            advancedOptionsCheckBox.setChecked(true);
+        }
+        // focus & ime
+        uriEditText.requestFocus();
+        uriEditText.post(new Runnable() {
+            @Override
+            public void run() {
+                InputMethodManager imm = (InputMethodManager) getActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
+                imm.showSoftInput(uriEditText, InputMethodManager.SHOW_IMPLICIT);
+            }
+        });
+    }
+
+    private HttpUriPreference getHttpUriPreference() {
+        return (HttpUriPreference) getPreference();
+    }
+
+    @Override
+    public void onDialogClosed(boolean positiveResult) {
+        if (positiveResult) {
+            String uri = uriEditText.getText().toString();
+            if (getHttpUriPreference().callChangeListener(uri)) {
+                getHttpUriPreference().setUri(uri);
+            }
+            String username = usernameEditText.getText().toString();
+            if (getHttpUriPreference().callOnUsernameChangeListener(username)) {
+                getHttpUriPreference().setUsername(username);
+            }
+            String password = passwordEditText.getText().toString();
+            if (getHttpUriPreference().callOnPasswordChangeListener(password)) {
+                getHttpUriPreference().setPassword(password);
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/dialog_http_uri_preference.xml
+++ b/app/src/main/res/layout/dialog_http_uri_preference.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:tools="http://schemas.android.com/tools"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginTop="48dp"
+            android:layout_marginBottom="48dp"
+            android:overScrollMode="ifContentScrolls"
+            tools:ignore="LabelFor">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="8dp"
+        android:paddingBottom="4dp"
+        android:orientation="vertical">
+
+        <EditText
+            android:id="@+id/et_uri"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="20dp"
+            android:layout_marginRight="20dp"
+            android:inputType="textUri"/>
+
+        <CheckBox
+            android:id="@+id/cb_advanced_options"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="20dp"
+            android:layout_marginRight="20dp"
+            android:text="@string/show_advanced_options"/>
+
+        <LinearLayout
+            android:id="@+id/ll_advanced_options_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:visibility="gone">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="24dp"
+                android:layout_marginRight="24dp"
+                android:text="@string/http_username"/>
+
+            <EditText
+                android:id="@+id/et_http_username"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="20dp"
+                android:layout_marginRight="20dp"
+                android:inputType="textNoSuggestions"/>
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="24dp"
+                android:layout_marginRight="24dp"
+                android:text="@string/http_password"/>
+
+            <EditText
+                android:id="@+id/et_http_password"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="20dp"
+                android:layout_marginRight="20dp"
+                android:inputType="textPassword"/>
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+</ScrollView>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -62,4 +62,8 @@
         <item>QQ 国际版</item>
         <item>QQ 日本版</item>
     </string-array>
+    <string name="http_username">HTTP 用户名</string>
+    <string name="http_password">HTTP 密码</string>
+    <string name="show_advanced_options">显示高级选项</string>
+    <string name="summary_uri_when_authorization_set">%s (附加登录信息)</string>
 </resources>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="HttpUriPreference">
+        <attr name="key_http_username" format="string"/>
+        <attr name="key_http_password" format="string"/>
+        <attr name="summary_when_authorization_set" format="string"/>
+    </declare-styleable>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,4 +61,8 @@
         <item>QQ International</item>
         <item>QQ Japan</item>
     </string-array>
+    <string name="http_username">HTTP Username</string>
+    <string name="http_password">HTTP Password</string>
+    <string name="show_advanced_options">Show advanced options</string>
+    <string name="summary_uri_when_authorization_set">%s (with authorization)</string>
 </resources>

--- a/app/src/main/res/xml/preference.xml
+++ b/app/src/main/res/xml/preference.xml
@@ -1,18 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--suppress ALL -->
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+                  xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <Preference
         android:key="view_token"
         android:title="@string/view_token"
         android:summary="@string/view_token_summary"/>
 
-    <EditTextPreference
+    <moe.shizuku.fcmformojo.preference.HttpUriPreference
         android:key="server_url"
+        app:key_http_username="server_http_username"
+        app:key_http_password="server_http_password"
         android:title="@string/server_url"
         android:summary="%s"
+        app:summary_when_authorization_set="@string/summary_uri_when_authorization_set"
         android:selectAllOnFocus="true"
-        android:inputType="textUri"
         android:defaultValue="http://0.0.0.0:5000"/>
 
     <SimpleMenuPreference


### PR DESCRIPTION
~~prpr RIkka~~

## Mojo 的后端看起来基本上是完全开放的。暴露出端口很容易被。。。

因此可以用 nginx 什么的弄个反代加 basic auth 保护一下，这个 Pull Request 在客户端上支持此功能。
+ 在「服务器 URL」设置中，勾选「显示高级选项」可设置用户名和密码。
+ 使用 OkHttp 拦截器实现登录 Header 的添加。
