### PR TITLE
Add Profile for QQ, QQi and QQL

### DIFF
--- a/app/src/main/java/moe/shizuku/fcmformojo/profile/QQLProfile.java
+++ b/app/src/main/java/moe/shizuku/fcmformojo/profile/QQLProfile.java
@@ -1,8 +1,12 @@
 package moe.shizuku.fcmformojo.profile;
 
+import android.annotation.SuppressLint;
+import android.content.ComponentName;
 import android.content.Context;
+import android.content.Intent;
 
 import moe.shizuku.fcmformojo.R;
+import moe.shizuku.fcmformojo.compat.ShizukuCompat;
 import moe.shizuku.fcmformojo.model.Chat;
 
 /**
@@ -31,13 +35,31 @@ public class QQLProfile implements Profile {
         return R.color.colorNotification;
     }
 
+    @SuppressLint("WrongConstant")
     @Override
     public void onStartChatActivity(Context context, Chat chat) {
-        ProfileHelper.startLauncherActivity(context, this);
+        Intent intent = new Intent("com.tencent.qqlite.action.CHAT")
+                .setComponent(ComponentName.unflattenFromString("com.tencent.qqlite/com.tencent.mobileqq.activity.ChatActivity"))
+                .setFlags(0x14000000)
+                .putExtra("entrance", 6)
+                .putExtra("key_notification_click_action", true)
+                .putExtra("uinname", chat.getName())
+                .putExtra("uintype", chat.getType())
+                .putExtra("uin", Long.toString(chat.getUid()))
+                .putExtra("incoming_senderuin", Long.toString(chat.getUid()));
+
+        if (!ShizukuCompat.startActivity(context, intent, getPackageName())) {
+            ProfileHelper.startLauncherActivity(context, this);
+        }
     }
 
     @Override
     public void onStartQrCodeScanActivity(Context context) {
-        ProfileHelper.startLauncherActivity(context, this);
+        Intent intent = new Intent()
+                .setClassName(getPackageName(), "com.tencent.biz.qrcode.activity.ScannerActivity")
+                .setComponent(ComponentName.unflattenFromString("com.tencent.qqlite/com.tencent.biz.qrcode.activity.ScannerActivity"));
+        if (!ShizukuCompat.startActivity(context, intent, getPackageName())) {
+            ProfileHelper.startLauncherActivity(context, this);
+        }
     }
 }

--- a/app/src/main/java/moe/shizuku/fcmformojo/profile/QQProfile.java
+++ b/app/src/main/java/moe/shizuku/fcmformojo/profile/QQProfile.java
@@ -1,8 +1,12 @@
 package moe.shizuku.fcmformojo.profile;
 
+import android.annotation.SuppressLint;
+import android.content.ComponentName;
 import android.content.Context;
+import android.content.Intent;
 
 import moe.shizuku.fcmformojo.R;
+import moe.shizuku.fcmformojo.compat.ShizukuCompat;
 import moe.shizuku.fcmformojo.model.Chat;
 
 /**
@@ -31,13 +35,31 @@ public class QQProfile implements Profile {
         return R.color.colorNotification;
     }
 
+    @SuppressLint("WrongConstant")
     @Override
     public void onStartChatActivity(Context context, Chat chat) {
-        ProfileHelper.startLauncherActivity(context, this);
+        Intent intent = new Intent("com.tencent.mobileqq.action.MAINACTIVITY")
+                .setComponent(ComponentName.unflattenFromString("com.tencent.mobileqq/com.tencent.mobileqq.activity.SplashActivity"))
+                .setFlags(0x14000000)
+                .putExtra("open_chatfragment", true)
+                .putExtra("entrance", 6)
+                .putExtra("key_notification_click_action", true)
+                .putExtra("uinname", chat.getName())
+                .putExtra("uintype", chat.getType())
+                .putExtra("uin", Long.toString(chat.getUid()));
+
+        if (!ShizukuCompat.startActivity(context, intent, getPackageName())) {
+            ProfileHelper.startLauncherActivity(context, this);
+        }
     }
 
     @Override
     public void onStartQrCodeScanActivity(Context context) {
-        ProfileHelper.startLauncherActivity(context, this);
+        Intent intent = new Intent()
+                .setClassName(getPackageName(), "com.tencent.biz.qrcode.activity.ScannerActivity")
+                .setComponent(ComponentName.unflattenFromString("com.tencent.mobileqq/com.tencent.biz.qrcode.activity.ScannerActivity"));
+        if (!ShizukuCompat.startActivity(context, intent, getPackageName())) {
+            ProfileHelper.startLauncherActivity(context, this);
+        }
     }
 }

--- a/app/src/main/java/moe/shizuku/fcmformojo/profile/QQiProfile.java
+++ b/app/src/main/java/moe/shizuku/fcmformojo/profile/QQiProfile.java
@@ -1,8 +1,12 @@
 package moe.shizuku.fcmformojo.profile;
 
+import android.annotation.SuppressLint;
+import android.content.ComponentName;
 import android.content.Context;
+import android.content.Intent;
 
 import moe.shizuku.fcmformojo.R;
+import moe.shizuku.fcmformojo.compat.ShizukuCompat;
 import moe.shizuku.fcmformojo.model.Chat;
 
 /**
@@ -31,13 +35,30 @@ public class QQiProfile implements Profile {
         return R.color.colorNotification;
     }
 
+    @SuppressLint("WrongConstant")
     @Override
     public void onStartChatActivity(Context context, Chat chat) {
-        ProfileHelper.startLauncherActivity(context, this);
+        Intent intent = new Intent()
+                .setComponent(ComponentName.unflattenFromString("com.tencent.mobileqqi/com.tencent.mobileqq.activity.ChatActivity"))
+                .setFlags(0x14000000)
+                .putExtra("entrance", 6)
+                .putExtra("key_notification_click_action", true)
+                .putExtra("uinname", chat.getName())
+                .putExtra("uintype", chat.getType())
+                .putExtra("uin", Long.toString(chat.getUid()));
+
+        if (!ShizukuCompat.startActivity(context, intent, getPackageName())) {
+            ProfileHelper.startLauncherActivity(context, this);
+        }
     }
 
     @Override
     public void onStartQrCodeScanActivity(Context context) {
-        ProfileHelper.startLauncherActivity(context, this);
+        Intent intent = new Intent()
+                .setClassName(getPackageName(), "com.tencent.biz.qrcode.activity.ScannerActivity")
+                .setComponent(ComponentName.unflattenFromString("com.tencent.mobileqqi/com.tencent.biz.qrcode.activity.ScannerActivity"));
+        if (!ShizukuCompat.startActivity(context, intent, getPackageName())) {
+            ProfileHelper.startLauncherActivity(context, this);
+        }
     }
 }


### PR DESCRIPTION
## Intent information
https://gist.github.com/haruue/56f7529a0efba4576228688e46be045f

## Work perfectly
- QQProfile.onStartChatActivity()
- QQiProfile.onStartChatActivity()

## SecurityException: (Maybe work with Shizuku)
- QQProfile.onStartQrCodeScanActivity()
- QQiProfile.onStartQrCodeScanActivity()
- QQLProfile.onStartChatActivity()
- QQLProfile.onStartQrCodeScanActivity()

## Unable to get a valid notification
- QQJPProfile
- QQHDProfile